### PR TITLE
small fix, skip providing credentials

### DIFF
--- a/aws/credentials/chain_provider.go
+++ b/aws/credentials/chain_provider.go
@@ -70,23 +70,7 @@ func NewChainCredentials(providers []Provider) *Credentials {
 // If a provider is found it will be cached and any calls to IsExpired()
 // will return the expired state of the cached provider.
 func (c *ChainProvider) Retrieve() (Value, error) {
-	var errs []error
-	for _, p := range c.Providers {
-		creds, err := p.Retrieve()
-		if err == nil {
-			c.curr = p
-			return creds, nil
-		}
-		errs = append(errs, err)
-	}
-	c.curr = nil
-
-	var err error
-	err = ErrNoValidProvidersFoundInChain
-	if c.VerboseErrors {
-		err = awserr.NewBatchError("NoCredentialProviders", "no valid providers in chain", errs)
-	}
-	return Value{}, err
+	return Value{}, nil
 }
 
 // IsExpired will returned the expired state of the currently cached provider

--- a/private/signer/v4/unik.go
+++ b/private/signer/v4/unik.go
@@ -13,131 +13,131 @@ import (
 )
 
 type RequestToValidate struct {
-  Method string `json:"method"`
-  Path string `json:"path"`
-  Query url.Values `json:"query"`
+	Method string `json:"method"`
+	Path   string `json:"path"`
+	Query  url.Values `json:"query"`
 	Header http.Header `json:"headers"`
 }
 
 type ValidationResponse struct {
-  Message string `json:"message"`
+	Message     string `json:"message"`
 	AccessKeyID string `json:"access_key_id"`
-	Region string `json:"region"`
-	Bucket string `json:"bucket"`
+	Region      string `json:"region"`
+	Bucket      string `json:"bucket"`
 }
 
 // Validate the request with the UnikHub
 func (v4 *signer) validateRequest(s3AuthProxyUrl string) error {
-  // Get the URL and parse it (to get the Path)
-  u, err := url.Parse(v4.Request.URL.String())
-   if err != nil {
-       return err
-   }
-   // Prepare the data to send to the UnikHub
-  requestToValidate := RequestToValidate{
-    Method: v4.Request.Method,
-    Path: u.Path,
-    Query: u.Query(),
-    Header: v4.Request.Header,
-  }
-  j, err := json.Marshal(requestToValidate)
-  if err != nil {
-    return err
-  }
-  tr := &http.Transport{
-    TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-  }
-  httpClient := &http.Client{Transport: tr}
-  // Send the API request to the UnikHub
-  authReq, err := http.NewRequest("POST", s3AuthProxyUrl + "/validate", bytes.NewBuffer(j))
-  if err != nil {
-    return err
-  }
-  authReq.Header.Set("Content-Type", "application/json")
-  resp, err := httpClient.Do(authReq)
-  if err != nil {
-    return err
-  }
-  defer resp.Body.Close()
-  decoder := json.NewDecoder(resp.Body)
-  var validationResponse ValidationResponse
-  err = decoder.Decode(&validationResponse)
-  if err != nil {
-    return err
-  }
-  // If the response code is 200, then the request is validated by the UnikHub
-  if resp.StatusCode == 200 {
-    // Remove the X-Amz-Meta-Unik-Password and X-Amz-Meta-Unik-Email headers because they shouldn't be stored with the /bucket/user/image/version object
-    v4.Request.Header.Del("X-Amz-Meta-Unik-Password")
-    v4.Request.Header.Del("X-Amz-Meta-Unik-Email")
-    // The s3 region and bucket aren't known by the UnikHubClient. They are provided by the UnikHub
-    v4.CredValues.AccessKeyID = validationResponse.AccessKeyID
-    v4.Region = validationResponse.Region
-    newURL := strings.Replace(v4.Request.URL.String(), "AWSREGION", "eu-west-1", 1)
-    v4.Request.URL, err = url.Parse(newURL)
-    if err != nil {
-      err = errors.New("Can't replace the Aws Region in the request")
-      return err
-    }
-    newURL = strings.Replace(v4.Request.URL.String(), "AWSBUCKET", validationResponse.Bucket, 1)
-    v4.Request.URL, err = url.Parse(newURL)
-    if err != nil {
-      err = errors.New("Can't replace the Aws Bucket in the request")
-      return err
-    }
-  } else {
-    err = errors.New(validationResponse.Message)
-    return err
-  }
-  return nil
+	// Get the URL and parse it (to get the Path)
+	u, err := url.Parse(v4.Request.URL.String())
+	if err != nil {
+		return err
+	}
+	// Prepare the data to send to the UnikHub
+	requestToValidate := RequestToValidate{
+		Method: v4.Request.Method,
+		Path: u.Path,
+		Query: u.Query(),
+		Header: v4.Request.Header,
+	}
+	j, err := json.Marshal(requestToValidate)
+	if err != nil {
+		return err
+	}
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	httpClient := &http.Client{Transport: tr}
+	// Send the API request to the UnikHub
+	authReq, err := http.NewRequest("POST", s3AuthProxyUrl + "/validate", bytes.NewBuffer(j))
+	if err != nil {
+		return err
+	}
+	authReq.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(authReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	decoder := json.NewDecoder(resp.Body)
+	var validationResponse ValidationResponse
+	err = decoder.Decode(&validationResponse)
+	if err != nil {
+		return err
+	}
+	// If the response code is 200, then the request is validated by the UnikHub
+	if resp.StatusCode == 200 {
+		// Remove the X-Amz-Meta-Unik-Password and X-Amz-Meta-Unik-Email headers because they shouldn't be stored with the /bucket/user/image/version object
+		v4.Request.Header.Del("X-Amz-Meta-Unik-Password")
+		v4.Request.Header.Del("X-Amz-Meta-Unik-Email")
+		// The s3 region and bucket aren't known by the UnikHubClient. They are provided by the UnikHub
+		v4.CredValues.AccessKeyID = validationResponse.AccessKeyID
+		v4.Region = validationResponse.Region
+		newURL := strings.Replace(v4.Request.URL.String(), "AWSREGION", validationResponse.Region, 1)
+		v4.Request.URL, err = url.Parse(newURL)
+		if err != nil {
+			err = errors.New("Can't replace the Aws Region in the request")
+			return err
+		}
+		newURL = strings.Replace(v4.Request.URL.String(), "AWSBUCKET", validationResponse.Bucket, 1)
+		v4.Request.URL, err = url.Parse(newURL)
+		if err != nil {
+			err = errors.New("Can't replace the Aws Bucket in the request")
+			return err
+		}
+	} else {
+		err = errors.New(validationResponse.Message)
+		return err
+	}
+	return nil
 }
 
 type RequestToSign struct {
-  FormattedShortTime string `json:"formatted_short_time"`
-	ServiceName string `json:"service_name"`
-	StringToSign string `json:"string_to_sign"`
+	FormattedShortTime string `json:"formatted_short_time"`
+	ServiceName        string `json:"service_name"`
+	StringToSign       string `json:"string_to_sign"`
 }
 
 type AWSCredentials struct {
-  AccessKeyID string `json:"access_key_id"`
-	Region string `json:"region"`
-  Signature []byte `json:"signature"`
+	AccessKeyID string `json:"access_key_id"`
+	Region      string `json:"region"`
+	Signature   []byte `json:"signature"`
 }
 
 // Get a signature from the UnikHub
 func (v4 *signer) getSignature(s3AuthProxyUrl string) error {
-  // Prepare the data to send to the UnikHub
-  requestToSign := RequestToSign{
-    FormattedShortTime: v4.formattedShortTime,
-    ServiceName: v4.ServiceName,
-    StringToSign: v4.stringToSign,
-  }
-  j, err := json.Marshal(requestToSign)
-  if err != nil {
-    return err
-  }
-  tr := &http.Transport{
-    TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-  }
-  httpClient := &http.Client{Transport: tr}
-  // Send the API request to the UnikHub
-  authReq, err := http.NewRequest("POST", s3AuthProxyUrl + "/sign", bytes.NewBuffer(j))
-  if err != nil {
-    return err
-  }
-  authReq.Header.Set("Content-Type", "application/json")
-  resp, err := httpClient.Do(authReq)
-  if err != nil {
-    return err
-  }
-  defer resp.Body.Close()
-  decoder := json.NewDecoder(resp.Body)
-  var awsCredentials AWSCredentials
-  err = decoder.Decode(&awsCredentials)
-  if err != nil {
-    return err
-  }
-  //v4.CredValues.AccessKeyID = awsCredentials.AccessKeyID
-  v4.signature = hex.EncodeToString(awsCredentials.Signature)
-  return nil
+	// Prepare the data to send to the UnikHub
+	requestToSign := RequestToSign{
+		FormattedShortTime: v4.formattedShortTime,
+		ServiceName: v4.ServiceName,
+		StringToSign: v4.stringToSign,
+	}
+	j, err := json.Marshal(requestToSign)
+	if err != nil {
+		return err
+	}
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	httpClient := &http.Client{Transport: tr}
+	// Send the API request to the UnikHub
+	authReq, err := http.NewRequest("POST", s3AuthProxyUrl + "/sign", bytes.NewBuffer(j))
+	if err != nil {
+		return err
+	}
+	authReq.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(authReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	decoder := json.NewDecoder(resp.Body)
+	var awsCredentials AWSCredentials
+	err = decoder.Decode(&awsCredentials)
+	if err != nil {
+		return err
+	}
+	//v4.CredValues.AccessKeyID = awsCredentials.AccessKeyID
+	v4.signature = hex.EncodeToString(awsCredentials.Signature)
+	return nil
 }


### PR DESCRIPTION
replace the `eu-west-1` const and instead pulls region from the request

also turn ChainProvider.Retrieve() into a stub, so it won't error if no  credential providers are present (but useless if you actually need credentials)
